### PR TITLE
fix: more flexible dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
         "@angular/platform-browser": "^2.4.1",
         "core-js": "2.4.1",
         "rimraf": "^2.5.4",
-        "rxjs": "5.0.2",
-        "typescript": "2.0.10",
-        "zone.js": "0.7.4"
+        "rxjs": "^5.0.2",
+        "typescript": "^2.0.10",
+        "zone.js": "^0.7.4"
     },
     "devDependencies": {
         "@angular/compiler-cli": "^2.4.1",


### PR DESCRIPTION
otherwise, the library will pull another copy of the dependencies if the project uses a different version