### PR TITLE
fix: remove unnecessary <any> typecasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ export class BatteryLevelService {
         return this.ble
 
           // 1) call the discover method will trigger the discovery process (by the browser)
-          .discover$({ filters: [], optionalServices: [BatteryLevelService.GATT_PRIMARY_SERVICE] as any })
+          .discover$({ filters: [], optionalServices: [BatteryLevelService.GATT_PRIMARY_SERVICE] })
           // 2) get that service
           .mergeMap(gatt => this.ble.getPrimaryService$(gatt, BatteryLevelService.GATT_PRIMARY_SERVICE))
           // 3) get a specific characteristic on that service

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@angular/compiler": "^2.4.7",
     "@angular/core": "^2.4.7",
     "@angular/platform-browser": "^2.4.7",
-    "@types/web-bluetooth": "^0.0.1",
+    "@types/web-bluetooth": "^0.0.2",
     "core-js": "2.4.1",
     "rimraf": "^2.5.4",
     "rxjs": "^5.0.2",

--- a/src/lib/bluetooth.service.ts
+++ b/src/lib/bluetooth.service.ts
@@ -84,8 +84,7 @@ export class BluetoothCore extends ReplaySubject<any /* find a better interface 
   discover(options: RequestDeviceOptions = <RequestDeviceOptions>{}) {
 
     options.filters = options.filters || this.anyDeviceFilter();
-    // TODO: remove typecast below once web-bluetooth typings allow for strings in optionalServices
-    options.optionalServices = (options.optionalServices || ['generic_access']) as number[];
+    options.optionalServices = options.optionalServices || ['generic_access'];
 
     console.log('[BLE::Info] Requesting devices with options %o', options);
 
@@ -200,14 +199,14 @@ export class BluetoothCore extends ReplaySubject<any /* find a better interface 
 
           char.startNotifications().then( _ =>  {
             console.log('[BLE::Info] Starting notifications of "%s"', characteristic);
-            return (<any>char).addEventListener('characteristicvaluechanged', this.onCharacteristicChanged.bind(this));
+            return char.addEventListener('characteristicvaluechanged', this.onCharacteristicChanged.bind(this));
           }, error => {
             console.error('[BLE::Error] Cannot start notification of "%s" %o', characteristic, error);
           });
 
         }
         else {
-          (<any>char).addEventListener('characteristicvaluechanged', this.onCharacteristicChanged.bind(this));
+          char.addEventListener('characteristicvaluechanged', this.onCharacteristicChanged.bind(this));
         }
 
         return char;
@@ -319,7 +318,7 @@ export class BluetoothCore extends ReplaySubject<any /* find a better interface 
   observeValue$(characteristic: BluetoothRemoteGATTCharacteristic): Observable<DataView> {
     characteristic.startNotifications();
     const disconnected = Observable.fromEvent(characteristic.service.device, 'gattserverdisconnected');
-    return Observable.fromEvent(characteristic as any, 'characteristicvaluechanged')
+    return Observable.fromEvent(characteristic, 'characteristicvaluechanged')
       .takeUntil(disconnected)
       .map((event: Event) => (event.target as BluetoothRemoteGATTCharacteristic).value as DataView);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,9 +46,9 @@
   version "6.0.54"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.54.tgz#65859962ba988052cbdd5c48881395acfdd46931"
 
-"@types/web-bluetooth@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.1.tgz#60decc5f599bda4707086c8b90f3625265485c7c"
+"@types/web-bluetooth@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@types/web-bluetooth/-/web-bluetooth-0.0.2.tgz#5cf081c320323543712c49c49ed520bf65eead1a"
 
 abbrev@1:
   version "1.1.0"


### PR DESCRIPTION
also upgrade @types/web-bluetooth to 0.0.2, which fixes the type of `optionalServices` in `RequestDeviceOptions`