### PR TITLE
fix: make `options` and `enableTracing` optional

### DIFF
--- a/src/lib/bluetooth.module.ts
+++ b/src/lib/bluetooth.module.ts
@@ -22,14 +22,14 @@ export function consoleLoggerService(options: Options) {
 }
 
 export interface Options {
-  enableTracing: boolean;
+  enableTracing?: boolean;
 }
 
 @NgModule({
   imports: [CommonModule]
 })
 export class WebBluetoothModule {
-    static forRoot(options: Options): ModuleWithProviders {
+    static forRoot(options: Options = {}): ModuleWithProviders {
     return {
       ngModule: WebBluetoothModule,
       providers: [


### PR DESCRIPTION
Disable tracing by default. This also makes the instructions in README work again (currently they fail)