### PR TITLE
Fix for issue 39

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Here 👉 https://manekinekko.github.io/angular-web-bluetooth/
 
 ## Need a starter?
 
+<img src="https://cloud.githubusercontent.com/assets/1699357/21523148/b843ceb0-cd0b-11e6-974a-50294a797b27.png"/>
+
 This project serves also as a starter. Run the following command:
 
 `npm start`

--- a/projects/angular-web-bluetooth/package-lock.json
+++ b/projects/angular-web-bluetooth/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@manekinekko/angular-web-bluetooth",
+  "version": "3.0.0",
+  "lockfileVersion": 1
+}

--- a/projects/angular-web-bluetooth/src/lib/bluetooth.service.ts
+++ b/projects/angular-web-bluetooth/src/lib/bluetooth.service.ts
@@ -136,10 +136,10 @@ export class BluetoothCore extends Subject<BluetoothCore> {
     this._console.log('[BLE::Info] Getting Characteristic "%s" of %o', characteristic, primaryService);
 
     const characteristicPromise = primaryService.getCharacteristic(characteristic).then(
-      char => {
+     async char => {
         // listen for characteristic value changes
         if (char.properties.notify) {
-          char.startNotifications().then(
+         await char.startNotifications().then(
             _ => {
               this._console.log('[BLE::Info] Starting notifications of "%s"', characteristic);
               return char.addEventListener('characteristicvaluechanged', this.onCharacteristicChanged.bind(this));


### PR DESCRIPTION
This is to fix #39. 

RCA: While fetching the characteristic, we are returning the promise which gets settled before we start notifications on that characteristic. To fix it, we need to make both the operations synchronous. 